### PR TITLE
Change R10K to r10k

### DIFF
--- a/examples/allinone/README.md
+++ b/examples/allinone/README.md
@@ -45,7 +45,7 @@ The Vagrantfile will automatically download a prepared CentOS box for you.
 You need to have R10K installed. You can use the one provided by the rubygem.
 
 ```
-ruby gem install R10K
+ruby gem install r10k
 ```
 
 Using R10K, module dependencies are automatically downloaded and the root of the module

--- a/examples/multinode/README.md
+++ b/examples/multinode/README.md
@@ -51,7 +51,7 @@ The Vagrantfile will automatically download a prepared CentOS box for you.
 You need to have R10K installed. You can use the one provided by the rubygem.
 
 ```
-gem install R10K
+sudo gem install r10k
 ```
 
 Using R10K, module dependencies are automatically downloaded and the root of the module

--- a/examples/multinode/README.md
+++ b/examples/multinode/README.md
@@ -51,7 +51,7 @@ The Vagrantfile will automatically download a prepared CentOS box for you.
 You need to have R10K installed. You can use the one provided by the rubygem.
 
 ```
-sudo gem install r10k
+gem install r10k
 ```
 
 Using R10K, module dependencies are automatically downloaded and the root of the module


### PR DESCRIPTION
When using `R10K` we got the error `Could not find a valid gem 'R10K' (>= 0) in any repository`. Change `R10K` to `r10k` can be installed.
